### PR TITLE
Fix env replacement and add missing env option

### DIFF
--- a/coe-cli/config/config.json
+++ b/coe-cli/config/config.json
@@ -1,4 +1,5 @@
 {
     "pat": "",
-    "upgrade": false
+    "upgrade": false,
+    "failOnMissingEnv": false
 }

--- a/coe-cli/src/common/config.ts
+++ b/coe-cli/src/common/config.ts
@@ -6,6 +6,7 @@ export class Config {
 
     static configSetup: boolean = false;
     static data: { [id: string]: any; } = {}
+    static failOnMissingEnv: boolean = false
 
     public static async init() {
         if (Config.configSetup) {
@@ -34,6 +35,8 @@ export class Config {
             await this.copyValue(devConfig, Config.data, devKeys[i])
           }
         }
+
+        Config.failOnMissingEnv = Config.data.failOnMissingEnv || false
 
         await this.replaceValues(Config.data)
    
@@ -85,8 +88,15 @@ export class Config {
           if (envRegexp.test(data[key])) {
             let match = envRegexp.exec(data[key]).groups
             let envValue = process.env[match["name"]]
-    
-            data[key] = data[key].replace("{env:" + match["name"] + "}", envValue)
+
+            if (envValue !== undefined) {
+              data[key] = data[key].replace("{env:" + match["name"] + "}", envValue)
+            } else {
+              if (Config.failOnMissingEnv) {
+                throw new Error(`Environment variable ${match["name"]} not found`)
+              }
+              data[key] = data[key].replace("{env:" + match["name"] + "}", "")
+            }
           }
         }
     

--- a/coe-cli/test/commands/commands.spec.ts
+++ b/coe-cli/test/commands/commands.spec.ts
@@ -576,6 +576,8 @@ const expectFile = async (args: string[], name: string) : Promise<void> => {
     var commands = new CoeCliCommands(logger);
     let readFileName = ''
 
+    const path = require('path')
+
     commands.readFile = (path: PathLike | FileHandle, options: { encoding: BufferEncoding, flag?: OpenMode } | BufferEncoding) => {
        readFileName = <string>path
        return Promise.resolve('')
@@ -586,5 +588,7 @@ const expectFile = async (args: string[], name: string) : Promise<void> => {
     await commands.execute(args)
 
     // Assert
-    expect(readFileName.indexOf(name) >= 0).toBeTruthy()
+    const normalized = path.normalize(readFileName)
+    const expected = path.join(...name.split('\\'))
+    expect(normalized.indexOf(expected) >= 0).toBeTruthy()
 }

--- a/coe-cli/test/common/config.spec.ts
+++ b/coe-cli/test/common/config.spec.ts
@@ -6,6 +6,8 @@ describe('Config', () => {
     test('Environment value', async () => {
 
         // Arrange
+        const originalTemp = process.env.TEMP
+        process.env.TEMP = originalTemp || '/tmp'
         Config.data = { "temp": "{env:TEMP}" }
 
         // Act
@@ -13,6 +15,36 @@ describe('Config', () => {
 
         // Assert
         expect(Config.data.temp).toBe(process.env.TEMP)
+        process.env.TEMP = originalTemp
+    })
+
+    test('Missing environment allowed', async () => {
+
+        // Arrange
+        const originalMissing = process.env.MISSING_VAR
+        delete process.env.MISSING_VAR
+        Config.configSetup = false
+        Config.data = { "value": "{env:MISSING_VAR}", failOnMissingEnv: false }
+
+        // Act
+        await Config.init()
+
+        // Assert
+        expect(Config.data.value).toBe("")
+        if (originalMissing) process.env.MISSING_VAR = originalMissing
+    })
+
+    test('Missing environment throws', async () => {
+
+        // Arrange
+        const originalMissing = process.env.MISSING_VAR
+        delete process.env.MISSING_VAR
+        Config.configSetup = false
+        Config.data = { "value": "{env:MISSING_VAR}", failOnMissingEnv: true }
+
+        // Act/Assert
+        await expect(Config.init()).rejects.toThrow('Environment variable MISSING_VAR not found')
+        if (originalMissing) process.env.MISSING_VAR = originalMissing
     })
 
     test('Config replacement', async () => {
@@ -63,3 +95,4 @@ describe('Config', () => {
         expect(data.child.other).toBe("123")
     })
 })
+


### PR DESCRIPTION
## Summary
- add `failOnMissingEnv` option to config
- throw an error in `replaceValues` when a required env var is missing and the flag is enabled
- test missing environment variable scenarios
- normalize path expectations and fix newline warnings

## Testing
- `npm test --silent -- -c jest.config.js`


------
https://chatgpt.com/codex/tasks/task_e_685af008de4083339ba91584aebab0be